### PR TITLE
improvement: Windows cannot use chmod, this chmod seems to be adding unnecessary execute permissions

### DIFF
--- a/create-zap-app/src/index.ts
+++ b/create-zap-app/src/index.ts
@@ -231,7 +231,6 @@ async function main() {
 
   // After installing dependencies
   spinner.clear();
-  spinner.text = "Ensuring executable permissions...";
 
   // Update dependencies
   spinner.clear();

--- a/create-zap-app/src/index.ts
+++ b/create-zap-app/src/index.ts
@@ -23,8 +23,6 @@ import {
 } from "./utils/index.js";
 import { fileURLToPath } from "url";
 
-const isWindows = process.platform === "win32";
-
 const __dirname = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const execAsync = promisify(exec);
 
@@ -234,16 +232,6 @@ async function main() {
   // After installing dependencies
   spinner.clear();
   spinner.text = "Ensuring executable permissions...";
-  // await execAsync("chmod -R u+x node_modules/.bin/*", { cwd: outputDir });
-
-  // If Windows, use icacls to grant RX permissions
-  // If not Windows, use chmod to set executable permissions
-  if (isWindows) {
-    const binDir = path.join(outputDir, "node_modules/.bin");
-    await execAsync(`icacls "${binDir}" /grant %USERNAME%:RX /T`, { cwd: outputDir });
-  } else {
-    await execAsync("chmod u+x node_modules/.bin/*", { cwd: outputDir });
-  }
 
   // Update dependencies
   spinner.clear();


### PR DESCRIPTION
Windows cannot use zap in its current state because zap tries to run chmod. I initially added a win32 check with equivalent permission modifications  as seen here: https://github.com/alexandretrotel/zap.ts/commit/1a9de5c3e9a149c358fc777ac511c36b5954b28c but I found that this doesn't even look to be needed.

I was able to build and run a zap app without any issues on Windows and Ubuntu without needing this chmod line, nor did I need to adjust file permissions on Windows for the .bin/ folder. Do you know why you needed this? Was there a dependency that wouldn't run right? 

It seems like an unnecessary security risk, we don't want to increase attack surfaces any more than they need to be.

Build output from Ubuntu after having removed the chmod command:
```
raat@raat-vmware:~/Desktop/zap.ts/create-zap-app$ npm run build

> create-zap-app@1.0.22 build
> bun build src/index.ts --outdir dist --target node

Bundled 472 modules in 437ms

  index.js12.87 MB  (entry point)

raat@raat-vmware:~/Desktop/zap.ts/create-zap-app$ npm start

> create-zap-app@1.0.22 start
> bun run dist/index.js


🚀 Welcome to create-zap-app! Let’s build something awesome.

? Which package manager do you want to use? pnpm
? Which ORM do you want? drizzle-orm
? Which plugins do you want? emails, legal, pwa
✔ Project setup complete!

🎉 Project created successfully!

Get started:
  cd my-zap-app
  pnpm dev

raat@raat-vmware:~/Desktop/zap.ts/create-zap-app$ cd my-zap-app/
raat@raat-vmware:~/Desktop/zap.ts/create-zap-app/my-zap-app$ pnpm dev

> @zap-ts/core@1.0.0 dev /home/raat/Desktop/zap.ts/create-zap-app/my-zap-app
> next dev --turbopack

   ▲ Next.js 15.2.2 (Turbopack)
   - Local:        http://localhost:3000
   - Network:      http://192.168.22.129:3000
   - Environments: .env.local
   - Experiments (use with caution):
     · turbo

 ✓ Starting...
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

 ✓ Compiled in 15s
 ✓ Ready in 17.4s
 ○ Compiling / ...
 ✓ Compiled / in 36.9s
 GET / 200 in 39832ms
 ○ Compiling /favicon.ico ...
 ✓ Compiled /favicon.ico in 4.1s
 GET /favicon.ico?favicon.40065fac.ico 200 in 4883ms
```