### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/alexandretrotel/zap.ts/security/code-scanning/1](https://github.com/alexandretrotel/zap.ts/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since this is a basic linting workflow, it only requires `contents: read` permissions to access the repository's code. This change will ensure that the workflow adheres to the principle of least privilege and does not inadvertently grant unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
