### PR TITLE
fix: respect REQUIRE_EMAIL_VERIFICATION setting in auth middleware

### DIFF
--- a/core/src/middleware.ts
+++ b/core/src/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 
 import { $fetch } from "@/lib/fetch";
 import type { Session } from "@/zap/lib/auth/client";
+import { ZAP_DEFAULT_SETTINGS } from "@/zap.config";
 
 const publicPaths = [
   "/",
@@ -51,7 +52,10 @@ export async function middleware(request: NextRequest) {
     }
 
     // Check email verification
-    if (!session.user || !session.user.emailVerified) {
+    if (
+      ZAP_DEFAULT_SETTINGS.AUTH.REQUIRE_EMAIL_VERIFICATION &&
+      (!session.user || !session.user.emailVerified)
+    ) {
       const verifyUrl = new URL("/login", request.url);
       verifyUrl.searchParams.set("redirect", pathname);
       return NextResponse.redirect(verifyUrl);


### PR DESCRIPTION
Fixes an issue where the authentication middleware was always requiring email verification regardless of the `ZAP_DEFAULT_SETTINGS.AUTH.REQUIRE_EMAIL_VERIFICATION` configuration setting.

## Problem
Users were unable to log in after registration even when `REQUIRE_EMAIL_VERIFICATION` was set to `false`. The middleware was unconditionally checking for email verification status, ignoring the configuration.

## Solution
Added a condition to check `ZAP_DEFAULT_SETTINGS.AUTH.REQUIRE_EMAIL_VERIFICATION` before enforcing email verification requirements.

## Changes
- Modified auth middleware to respect the `REQUIRE_EMAIL_VERIFICATION` setting
- Users can now bypass email verification when the setting is disabled
- Maintains existing behavior when email verification is required

Fixes the login flow for configurations where email verification is optional.