### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,4 +1,7 @@
 name: Discord notification on PR merge
+permissions:
+  contents: read
+  pull-requests: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/alexandretrotel/zap.ts/security/code-scanning/2](https://github.com/alexandretrotel/zap.ts/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read pull request metadata to notify Discord, we will set `contents: read` and `pull-requests: read` permissions. This ensures that the workflow has the minimal permissions required to function correctly.

The changes will be made at the top level of the workflow file, immediately after the `name` field, to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
