### PR TITLE
fix: update vitepress dependencies to use catalog references

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,8 +6,8 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "@shikijs/vitepress-twoslash": "^3.18.0",
-    "vitepress": "^1.6.4",
-    "vitepress-plugin-llms": "^1.9.3"
+    "@shikijs/vitepress-twoslash": "catalog:vitepress",
+    "vitepress": "catalog:vitepress",
+    "vitepress-plugin-llms": "catalog:vitepress"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,16 @@ catalogs:
     tailwind-merge:
       specifier: ^3.4.0
       version: 3.4.0
+  vitepress:
+    '@shikijs/vitepress-twoslash':
+      specifier: ^3.18.0
+      version: 3.18.0
+    vitepress:
+      specifier: ^1.6.4
+      version: 1.6.4
+    vitepress-plugin-llms:
+      specifier: ^1.9.3
+      version: 1.9.3
 
 importers:
 
@@ -209,13 +219,13 @@ importers:
   apps/docs:
     devDependencies:
       '@shikijs/vitepress-twoslash':
-        specifier: ^3.18.0
+        specifier: catalog:vitepress
         version: 3.18.0(@nuxt/kit@3.20.1(magicast@0.5.1))(typescript@5.9.3)
       vitepress:
-        specifier: ^1.6.4
+        specifier: catalog:vitepress
         version: 1.6.4(@algolia/client-search@5.45.0)(@types/node@24.10.1)(fuse.js@7.1.0)(lightningcss@1.30.2)(postcss@8.5.6)(search-insights@2.17.3)(terser@5.44.1)(typescript@5.9.3)
       vitepress-plugin-llms:
-        specifier: ^1.9.3
+        specifier: catalog:vitepress
         version: 1.9.3
 
   apps/zap-ts-docs:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,6 +80,10 @@ catalogs:
     tailwind-merge: ^3.4.0
   vite:
     vite: npm:rolldown-vite@^7.2.8
+  vitepress:
+    '@shikijs/vitepress-twoslash': ^3.18.0
+    vitepress: ^1.6.4
+    vitepress-plugin-llms: ^1.9.3
 
 onlyBuiltDependencies:
   - '@parcel/watcher'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized dependency management by consolidating vitepress-related packages into a workspace catalog
  * Updated documentation build dependencies to reference centralized catalog entries instead of individual version pins

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->